### PR TITLE
add package 'libffi-devel'

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -1,3 +1,4 @@
+package "libffi-devel"
 package "openssl-devel"
 package "readline-devel"
 


### PR DESCRIPTION
- because fiddle depend on it at ruby 2.2.0
- [Ruby2.2.0のインストールがlibffi.a: could not read symbols: Bad valueで失敗した件 - まっしろけっけ](http://shiro-16.hatenablog.com/entry/2014/12/26/003810)
