### PR TITLE
Add rbenv_root configuration to node config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ rbenv:
     - 2.2.0
     - 2.1.5
 
+  # rbenv install dir, optional (default: /use/local/rbenv )
+  rbenv_root: "/path/to/rbenv"
+
 # revision of sstephenson/ruby-build, optional
 ruby-build:
   revision: e455975286e44393b1b33037ae1ce40ef2742401

--- a/lib/itamae-plugin-recipe-rbenv.rb
+++ b/lib/itamae-plugin-recipe-rbenv.rb
@@ -1,0 +1,1 @@
+require "itamae/plugin/recipe/rbenv"

--- a/lib/itamae/plugin/recipe/rbenv.rb
+++ b/lib/itamae/plugin/recipe/rbenv.rb
@@ -1,0 +1,11 @@
+def rbenv_root
+  "/usr/local/rbenv"
+end
+
+def rbenv_init
+  <<-EOS
+    export RBENV_ROOT=#{rbenv_root}
+    export PATH="#{rbenv_root}/bin:${PATH}"
+    eval "$(rbenv init --no-rehash -)"
+  EOS
+end

--- a/lib/itamae/plugin/recipe/rbenv.rb
+++ b/lib/itamae/plugin/recipe/rbenv.rb
@@ -1,5 +1,5 @@
 def rbenv_root
-  "/usr/local/rbenv"
+  node[:rbenv] && node[:rbenv][:rbenv_root] ? node[:rbenv][:rbenv_root] : "/usr/local/rbenv"
 end
 
 def rbenv_init

--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -2,18 +2,13 @@ package "libffi-devel"
 package "openssl-devel"
 package "readline-devel"
 
-RBENV_ROOT = "/usr/local/rbenv"
-RBENV_INIT = <<-EOS
-  export RBENV_ROOT=#{RBENV_ROOT}
-  export PATH="#{RBENV_ROOT}/bin:${PATH}"
-  eval "$(rbenv init --no-rehash -)"
-EOS
+require "itamae/plugin/recipe/rbenv"
 
-git RBENV_ROOT do
+git rbenv_root do
   repository "git://github.com/sstephenson/rbenv.git"
 end
 
-git "#{RBENV_ROOT}/plugins/ruby-build" do
+git "#{rbenv_root}/plugins/ruby-build" do
   repository "git://github.com/sstephenson/ruby-build.git"
   if node[:'ruby-build'] && node[:'ruby-build'][:revision]
     revision node[:'ruby-build'][:revision]
@@ -22,14 +17,14 @@ end
 
 node[:rbenv][:versions].each do |version|
   execute "rbenv install #{version}" do
-    command "#{RBENV_INIT} rbenv install #{version}"
-    not_if  "#{RBENV_INIT} rbenv versions | grep #{version}"
+    command "#{rbenv_init} rbenv install #{version}"
+    not_if  "#{rbenv_init} rbenv versions | grep #{version}"
   end
 end
 
 node[:rbenv][:global].tap do |version|
   execute "rbenv global #{version}" do
-    command "#{RBENV_INIT} rbenv global #{version}"
-    not_if  "#{RBENV_INIT} rbenv version | grep #{version}"
+    command "#{rbenv_init} rbenv global #{version}"
+    not_if  "#{rbenv_init} rbenv version | grep #{version}"
   end
 end


### PR DESCRIPTION
## Why?
I want to install rbenv to other than `/usr/local/rbenv`

## Overview
* Add rbenv_root configuration to node config file
* Tiny refactoring

## Example 1
node.yml

```yaml
rbenv:
  rbenv_root: "/path/to/rbenv"
```

## Example 2
 `rbenv_root` is shortcut method of `node[:rbenv][:rbenv_root]`

recipes/my_rbenv.rb

```ruby
include_recipe "rbenv::system"

require "itamae/plugin/recipe/rbenv"
# or
# require "itamae-plugin-recipe-rbenv"

# other provisioning
execute "chown jenkins:drecom -R #{rbenv_root}" do
  command "chown jenkins:jenkins -R #{rbenv_root}"
end

execute "chmod g+w -R #{rbenv_root}" do
  command "chmod g+w -R #{rbenv_root}"
end
```
