### PR TITLE
Support rbenv-default-gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ rbenv:
 # revision of sstephenson/ruby-build, optional
 ruby-build:
   revision: e455975286e44393b1b33037ae1ce40ef2742401
+
+rbenv-default-gems:
+  default-gems:
+    - bundler
+    - bcat ~>0.6
+    - rails --pre
+  # revision of sstephenson/rbenv-default-gems, optional
+  revision: ead67889c91c53ad967f85f5a89d986fdb98f6fb
 ```
 
 ### .bashrc

--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -15,6 +15,20 @@ git "#{rbenv_root}/plugins/ruby-build" do
   end
 end
 
+git "#{rbenv_root}/plugins/rbenv-default-gems" do
+  repository "git://github.com/sstephenson/rbenv-default-gems.git"
+  if node[:'rbenv-default-gems'] && node[:'rbenv-default-gems'][:revision]
+    revision node[:'rbenv-default-gems'][:revision]
+  end
+end
+
+if node[:'rbenv-default-gems'] && node[:'rbenv-default-gems'][:'default-gems']
+  file "#{rbenv_root}/default-gems" do
+    content node[:'rbenv-default-gems'][:'default-gems'].join("\n") + "\n"
+    mode    "664"
+  end
+end
+
 node[:rbenv][:versions].each do |version|
   execute "rbenv install #{version}" do
     command "#{rbenv_init} rbenv install #{version}"


### PR DESCRIPTION
Automatically install often used gems (ex. `bundler`) every time after `rbenv install`

cf. https://github.com/sstephenson/rbenv-default-gems

# Example
```yaml
# node.yml
rbenv-default-gems:
  default-gems:
    - bundler
    - bcat ~>0.6
    - rails --pre
  revision: ead67889c91c53ad967f85f5a89d986fdb98f6fb
```