### PR TITLE
use node[:platform] instead of os[:family]

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -1,5 +1,5 @@
 # cf) https://github.com/sstephenson/ruby-build/wiki#suggested-build-environment
-case os[:family]
+case node[:platform]
 when "debian", "ubuntu"
   package "autoconf"
   package "bison"


### PR DESCRIPTION
I got method_missing error with `os` function on latest itamae (version 1.2.10), so use `node[:platform]` and it's working.