### PR TITLE
Add git package

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -31,6 +31,8 @@ else
   package "readline-devel"
 end
 
+package "git"
+
 require "itamae/plugin/recipe/rbenv"
 
 git rbenv_root do


### PR DESCRIPTION
I had the following error because  `git` resource requires git package implicitly.
Should itamae-plugin-recipe-rbenv depend on `git` package?

```
/home/user/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/itamae-1.2.15/lib/itamae/resource/git.rb:62:in `ensure_git_available': `git` command is not available. Please install git. (RuntimeError)
```