### PR TITLE
Support rbenv-gem-rehash

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ rbenv-default-gems:
     - rails --pre
   # revision of sstephenson/rbenv-default-gems, optional
   revision: ead67889c91c53ad967f85f5a89d986fdb98f6fb
+
+# revision of sstephenson/rbenv-gem-rehash, optional
+rbenv-gem-rehash:
+  revision: 4d7b92de4bdf549df59c3c8feb1890116d2ea985
 ```
 
 ### .bashrc

--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -46,6 +46,13 @@ git "#{rbenv_root}/plugins/ruby-build" do
   end
 end
 
+git "#{rbenv_root}/plugins/rbenv-gem-rehash" do
+  repository "git://github.com/sstephenson/rbenv-gem-rehash.git"
+  if node[:'rbenv-gem-rehash'] && node[:'rbenv-gem-rehash'][:revision]
+    revision node[:'rbenv-gem-rehash'][:revision]
+  end
+end
+
 git "#{rbenv_root}/plugins/rbenv-default-gems" do
   repository "git://github.com/sstephenson/rbenv-default-gems.git"
   if node[:'rbenv-default-gems'] && node[:'rbenv-default-gems'][:revision]


### PR DESCRIPTION
Support [rbenv-gem-rehash](https://github.com/sstephenson/rbenv-gem-rehash). This plugin automatically runs `rbenv rehash`.