### PR TITLE
fix owner for a user

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -8,11 +8,16 @@ rbenv_root = node[:rbenv][:rbenv_root]
 git rbenv_root do
   repository "#{scheme}://github.com/rbenv/rbenv.git"
   revision node[:rbenv][:revision] if node[:rbenv][:revision]
+  user node[:rbenv][:user] if node[:rbenv][:user]
 end
 
-directory File.join(rbenv_root, 'plugins')
+directory File.join(rbenv_root, 'plugins') do
+  user node[:rbenv][:user] if node[:rbenv][:user]
+end
 if node[:rbenv][:cache]
-  directory File.join(rbenv_root, 'cache')
+  directory File.join(rbenv_root, 'cache') do
+    user node[:rbenv][:user] if node[:rbenv][:user]
+  end
 end
 
 define :rbenv_plugin do
@@ -22,6 +27,7 @@ define :rbenv_plugin do
     git "#{rbenv_root}/plugins/#{name}" do
       repository "#{scheme}://github.com/rbenv/#{name}.git"
       revision node[name][:revision] if node[name][:revision]
+      user node[:rbenv][:user] if node[:rbenv][:user]
     end
   end
 end
@@ -31,6 +37,7 @@ if node[:'rbenv-default-gems'] && node[:'rbenv-default-gems'][:'default-gems']
   file "#{rbenv_root}/default-gems" do
     content node[:'rbenv-default-gems'][:'default-gems'].join("\n") + "\n"
     mode    '664'
+    user node[:rbenv][:user] if node[:rbenv][:user]
   end
 end
 
@@ -47,6 +54,7 @@ node[:rbenv][:versions].each do |version|
   execute "rbenv install #{version}" do
     command "#{rbenv_init} rbenv install #{version}"
     not_if  "#{rbenv_init} rbenv versions | grep #{version}"
+    user node[:rbenv][:user] if node[:rbenv][:user]
   end
 end
 
@@ -55,6 +63,7 @@ if node[:rbenv][:global]
     execute "rbenv global #{version}" do
       command "#{rbenv_init} rbenv global #{version}"
       not_if  "#{rbenv_init} rbenv version | grep #{version}"
+      user node[:rbenv][:user] if node[:rbenv][:user]
     end
   end
 end


### PR DESCRIPTION
`include_recipe 'rbenv:user'`したときにデフォルトではsudoで実行されるので、
rbenv関連のファイルの所有者がrootになっています。
`node[:rbenv][:user]`が指定されていればそのユーザーを所有者とするように修正しました。