### PR TITLE
create symbolic link beacuse use mitamae

### DIFF
--- a/mrblib/mitamae
+++ b/mrblib/mitamae
@@ -1,0 +1,1 @@
+../lib/itamae

--- a/mrblib/mitamae/plugin
+++ b/mrblib/mitamae/plugin
@@ -1,0 +1,1 @@
+../../lib/itamae/plugin

--- a/mrblib/mitamae/plugin
+++ b/mrblib/mitamae/plugin
@@ -1,1 +1,0 @@
-../../lib/itamae/plugin


### PR DESCRIPTION
I use MItamae .

[README.md](https://github.com/k0kubun/itamae-plugin-recipe-rbenv#mitamae) writes ` Put this repository under ./plugins as git submodule.` .
But not working, Because directory structure is different.

MItamae include `plugins/{,m}itamae-plugin-recipe-#{name}/mrblib/{,m}itamae/plugin/recipe/#{name}`
https://github.com/k0kubun/mitamae/blob/master/mrblib/mitamae/plugin.rb#L32
But this recipe path is `mitamae/lib/itamae/plugin/recipe`.

I Fixed symbolic link.
Please check PR.