### PR TITLE
Add platform sample in node.yml usage

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -12,7 +12,7 @@ when 'debian', 'ubuntu', 'mint'
   package 'libssl-dev'
   package 'libyaml-dev'
   package 'zlib1g-dev'
-when 'redhat', 'fedora'
+when 'redhat', 'fedora', 'amazon'
   # redhat is including CentOS
   package 'bzip2'
   package 'gcc'


### PR DESCRIPTION
Hello,

I created a this Pull Request. This is a little appendix to Readme.md.

Because I got stuck in rbenv installation.

↓↓↓ Here is my episode.

---

I use this plugin toward Amazon linux

I built Ruby on Rails environment while I saw Readme.md node.yml usage.

First, I wrote node.yml

```
# node.yml

rbenv:
  global:
    2.3.3
  versions:
    - 2.3.3

  scheme: https
```

But I run itamae, when I happened a error.

```
 INFO : Starting Itamae...
 INFO : Loading node data from /Users/kawakubox/Workspace/generic-recipe/roles/rails/node.yml...
 INFO : Recipe: /Users/kawakubox/Workspace/generic-recipe/roles/rails/default.rb
 INFO :   Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/system.rb
 INFO :     Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/install.rb
 INFO :       Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/dependency.rb
 INFO :       execute[rbenv install 2.3.3] executed will change from 'false' to 'true'
ERROR :         stdout | Installing ruby-2.3.3...
ERROR :         stdout |
ERROR :         stdout | [1mBUILD FAILED[m (Amazon Linux AMI 2016.09 using ruby-build 20161121-14-gd799bdd)
ERROR :         stdout |
ERROR :         stdout | Inspect or clean up the working tree at /tmp/ruby-build.20161214144733.28704
ERROR :         stdout | [33mResults logged to /tmp/ruby-build.20161214144733.28704.log[m
ERROR :         stdout |
ERROR :         stdout | Last 10 log lines:
ERROR :         stdout | config.sub already exists
ERROR :         stdout | checking build system type... x86_64-pc-linux-gnu
ERROR :         stdout | checking host system type... x86_64-pc-linux-gnu
ERROR :         stdout | checking target system type... x86_64-pc-linux-gnu
ERROR :         stdout | checking for gcc... no
ERROR :         stdout | checking for cc... no
ERROR :         stdout | checking for cl.exe... no
ERROR :         stdout | configure: error: in `/tmp/ruby-build.20161214144733.28704/ruby-2.3.3':
ERROR :         stdout | configure: error: no acceptable C compiler found in $PATH
ERROR :         stdout | See `config.log' for more details
ERROR :         Command `  export RBENV_ROOT=/usr/local/rbenv
  export PATH="/usr/local/rbenv/bin:${PATH}"
  eval "$(rbenv init --no-rehash -)"
  rbenv install 2.3.3` failed. (exit status: 1)
ERROR :       execute[rbenv install 2.3.3] Failed.
```

I noticed my mistake, when I had reading `dependency.rb`

I tried to write `platform` key and `redhat` value in node.yml.

```
platform: redhat   # <-- appendix

rbenv:
  global:
    2.3.3
  versions:
    - 2.3.3

  scheme: https
```

I retried itamae.

```
 INFO : Starting Itamae...
 INFO : Loading node data from /Users/kawakubox/Workspace/generic-recipe/roles/rails/node.yml...
 INFO : Recipe: /Users/kawakubox/Workspace/generic-recipe/roles/rails/default.rb
 INFO :   Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/system.rb
 INFO :     Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/install.rb
 INFO :       Recipe: /Users/kawakubox/Workspace/generic-recipe/vendor/bundle/ruby/2.3.0/gems/itamae-plugin-recipe-rbenv-0.6.3/lib/itamae/plugin/recipe/rbenv/dependency.rb
 INFO :         package[gcc] installed will change from 'false' to 'true'
 INFO :         package[gdbm-devel] installed will change from 'false' to 'true'
 INFO :         package[libyaml-devel] installed will change from 'false' to 'true'
 INFO :       execute[rbenv install 2.3.3] executed will change from 'false' to 'true'
 INFO :       execute[rbenv global 2.3.3] executed will change from 'false' to 'true'
```

Yay!!!

---

I praying to reduce mistakes like me.