### PR TITLE
Fix ruby version checking for two-digits

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -61,7 +61,7 @@ end.join
 node[:rbenv][:versions].each do |version|
   execute "rbenv install #{version}" do
     command "#{rbenv_init} #{build_envs} rbenv install #{version}"
-    not_if  "#{rbenv_init} rbenv versions | grep #{version}"
+    not_if  "#{rbenv_init} rbenv versions --bare | grep -w #{version}"
     user node[:rbenv][:user] if node[:rbenv][:user]
   end
 end
@@ -70,7 +70,7 @@ if node[:rbenv][:global]
   node[:rbenv][:global].tap do |version|
     execute "rbenv global #{version}" do
       command "#{rbenv_init} rbenv global #{version}"
-      not_if  "#{rbenv_init} rbenv version | grep #{version}"
+      not_if  "#{rbenv_init} rbenv version --bare | grep -w #{version}"
       user node[:rbenv][:user] if node[:rbenv][:user]
     end
   end


### PR DESCRIPTION
```
$ rbenv versions
  system
  2.1.10

$ rbenv versions | grep 2.1.1
  2.1.10

$ rbenv versions --bare | grep -w 2.1.1
```