### PR TITLE
Add guard condition for packages to fix error on Debian

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -6,7 +6,7 @@ when 'debian', 'ubuntu', 'mint'
   package 'build-essential'
   package 'libffi-dev'
   package 'libgdbm-dev'
-  if node[:platform_version] >= '18.04'
+  if node[:platform] == 'ubuntu' && node[:platform_version] >= '18.04'
     package 'libgdbm5'
     package 'libreadline-dev'
   else


### PR DESCRIPTION
This condition is intended for Ubuntu.

- 323424d0f3743f1ae9c3961b201b53b6a4935fa6
- 80d3d37d6bd923561f080070622ff3729f7949d1

I've got following error on Debian stretch.

```
ERROR :           stdout | パッケージリストを読み込んでいます...
ERROR :           stdout | 依存関係ツリーを作成しています...
ERROR :           stdout | 状態情報を読み取っています...
ERROR :           stderr | E: パッケージ libgdbm5 が見つかりません
ERROR :           Command `DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'  install libgdbm5` failed. (exit status: 100)
ERROR :         package[libgdbm5] Failed.
```

In Debian stretch, the `node[:platform_version]` is `"9.5"` and it's greater than `"18.04"`.

```
$ mruby -e 'p "9.5" >= "18.04"'
true
```

But libgdbm5 is not in Debian stretch's repository.