### PR TITLE
Add install_dependency options to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ rbenv:
   # See: https://github.com/rbenv/ruby-build#package-download-caching
   cache: true
 
+  # Whether install dependencies (default: true)
+  # Recommend false if `--no-sudo`
+  install_dependency: true
+
 # ruby-build is always installed. Specifying revision improves performance.
 ruby-build:
   revision: e455975286e44393b1b33037ae1ce40ef2742401
@@ -109,6 +113,10 @@ rbenv:
   # Create ~/.rbenv/cache, optional (default: false)
   # See: https://github.com/rbenv/ruby-build#package-download-caching
   cache: true
+
+  # Whether install dependencies (default: true)
+  # Recommend false if `--no-sudo`
+  install_dependency: true
 
 # ruby-build is always installed. Specifying revision improves performance.
 ruby-build:

--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -1,6 +1,8 @@
 # This recipe requires `rbenv_root` is defined.
 
-include_recipe 'rbenv::dependency'
+if node[:rbenv][:install_dependency]
+  include_recipe 'rbenv::dependency'
+end
 
 scheme     = node[:rbenv][:scheme]
 rbenv_root = node[:rbenv][:rbenv_root]

--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -3,6 +3,7 @@ node.reverse_merge!(
     rbenv_root: '/usr/local/rbenv',
     scheme:     'git',
     versions:   [],
+    install_dependency: true,
   },
   :'ruby-build' => {
     install: true,

--- a/lib/itamae/plugin/recipe/rbenv/user.rb
+++ b/lib/itamae/plugin/recipe/rbenv/user.rb
@@ -3,6 +3,7 @@ node.reverse_merge!(
     scheme:   'git',
     user:     ENV['USER'],
     versions: [],
+    install_dependency: true,
   },
   :'ruby-build' => {
     install: true,


### PR DESCRIPTION
# Context
Sometimes I want to install rbenv as no-sudo user.

```ruby
# rbenv.rb
include_recipe "rbenv::user"
```

```bash
bundle exec itamae ssh rbenv.rb --node-yaml=node.yml --no-sudo --host=xxxxx
```

But `rbenv::dependency` implicitly requires sudo privilege. (e.g. `apt-get install`)

https://github.com/k0kubun/itamae-plugin-recipe-rbenv/blob/v0.6.7/lib/itamae/plugin/recipe/rbenv/dependency.rb

So I want to skip package install.

