### PR TITLE
Support arbitrary plugin install

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -87,7 +87,9 @@ node[:rbenv][:plugins].tap do |plugins|
     when String
       rbenv_plugin plugin
     else
-      rbenv_plugin plugin[:name], group: plugin[:group]
+      rbenv_plugin plugin[:name] do
+        group plugin[:group]
+      end
     end
   end
 end

--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -22,7 +22,7 @@ if node[:rbenv][:cache]
   end
 end
 
-define :rbenv_plugin, group: :rbenv do
+define :rbenv_plugin, group: 'rbenv' do
   name = params[:name]
   group = params[:group]
 
@@ -83,13 +83,9 @@ node[:rbenv][:plugins].tap do |plugins|
   next unless plugins
 
   plugins.each do |plugin|
-    case plugin
-    when String
-      rbenv_plugin plugin
-    else
-      rbenv_plugin plugin[:name] do
-        group plugin[:group]
-      end
+    grp = node[plugin][:group]
+    rbenv_plugin plugin do
+      group grp if grp
     end
   end
 end

--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -22,12 +22,13 @@ if node[:rbenv][:cache]
   end
 end
 
-define :rbenv_plugin do
+define :rbenv_plugin, group: :rbenv do
   name = params[:name]
+  group = params[:group]
 
   if node[name] && (node[name][:install] || node[name][:revision])
     git "#{rbenv_root}/plugins/#{name}" do
-      repository "#{scheme}://github.com/rbenv/#{name}.git"
+      repository "#{scheme}://github.com/#{group}/#{name}.git"
       revision node[name][:revision] if node[name][:revision]
       user node[:rbenv][:user] if node[:rbenv][:user]
     end
@@ -74,6 +75,19 @@ if node[:rbenv][:global]
       command "#{rbenv_init} rbenv global #{version}"
       not_if  "#{rbenv_init} rbenv version --bare | grep -x #{version}"
       user node[:rbenv][:user] if node[:rbenv][:user]
+    end
+  end
+end
+
+node[:rbenv][:plugins].tap do |plugins|
+  next unless plugins
+
+  plugins.each do |plugin|
+    case plugin
+    when String
+      rbenv_plugin plugin
+    else
+      rbenv_plugin plugin[:name], group: plugin[:group]
     end
   end
 end


### PR DESCRIPTION
This PR makes the user of this library add arbitrary github hosted plugin installs to rbenv.

For example, when one wants to add `rbenv-sudo` (https://github.com/dcarley/rbenv-sudo), one can write following node information to achieve it.

```yaml
rbenv:
  # some other configs....
  plugins:
    - rbenv-sudo

rbenv-sudo:
  install: true
  group: dcarley
```

Since this gem already takes care of installing some plugins (`ruby-build` and `rbenv-default-gems`), I thought it would be convenient for user if this gem takes care of the other plugins also.

Any opinion...?