### PR TITLE
Make installing arbitrary rbenv plugin feature run properly

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -22,12 +22,17 @@ if node[:rbenv][:cache]
   end
 end
 
-define :rbenv_plugin, group: 'rbenv', revision: nil do
+define :rbenv_plugin, group: 'rbenv', revision: nil, install: nil do
   name = params[:name]
   group = params[:group]
   rev = params[:revision]
+  if params[:install] == false
+    install = false
+  else
+    install = true
+  end
 
-  if node[name] && (node[name][:install] || node[name][:revision])
+  if install || rev
     git "#{rbenv_root}/plugins/#{name}" do
       repository "#{scheme}://github.com/#{group}/#{name}.git"
       revision rev if rev
@@ -39,6 +44,7 @@ end
 if node[:'rbenv-default-gems'] && node[:'rbenv-default-gems'][:'default-gems']
   rbenv_plugin 'rbenv-default-gems' do
     revision node[:'rbenv-default-gems'][:revision]
+    install node[:'rbenv-default-gems'][:install]
   end
 
   node[:'rbenv-default-gems'][:install] = true
@@ -54,6 +60,7 @@ end
 
 rbenv_plugin 'ruby-build' do
   revision node[:'ruby-build'][:revision]
+  install node[:'ruby-build'][:install]
 end
 
 rbenv_init = <<-EOS
@@ -86,7 +93,7 @@ end
 
 node[:rbenv][:plugins].each do |name, options|
   if name.include?('/')
-    owner, repo = spec.split('/', 2)
+    owner, repo = name.split('/', 2)
   else
     owner, repo = 'rbenv', name
   end


### PR DESCRIPTION
This patch consists of the following two points,

- Fixed a typo in splitting plugin name to owner and repository name.
- Determine without `node[:name]` variable whether to install a plugin.

The first point may be clear but we need to explain the second point.

Current README says that we can install rbenv plugins like following node configuration,

```yaml
rbenv:
  # :
    plugins:
    dcarley/rbenv-sudo:
      revision: master
  # :
```

However, we cannot install because of `node[name]` variable (in this situation, `node[:rbenv-sudo]`) returns nil.

I think it's not good to refer `node[name]` in `define :rbenv_plugin` block. So I added install parameter to the statement.

By doing this, we can let Itamae prevent to install plugin only if install parameter is set false explicitly.