### PR TITLE
Avoid unnecessary `rbenv global`

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/install.rb
+++ b/lib/itamae/plugin/recipe/rbenv/install.rb
@@ -85,7 +85,7 @@ if node[:rbenv][:global]
   node[:rbenv][:global].tap do |version|
     execute "rbenv global #{version}" do
       command "#{rbenv_init} rbenv global #{version}"
-      not_if  "#{rbenv_init} rbenv version --bare | grep -x #{version}"
+      not_if  "#{rbenv_init} rbenv global | grep -x #{version}"
       user node[:rbenv][:user] if node[:rbenv][:user]
     end
   end


### PR DESCRIPTION
# Problem


This plugin always executes `rbenv global` because the `not_if` does not work.

It specifies `rbenv version --bare | grep -x #{version}`.
I guess the `--bare` option expects to print only the version name, like "2.7.0", but it also print the origin.

```bash
$ rbenv version --bare
2.7.0 (set by /home/pocke/.rbenv/version)
```

Because `rbenv version` command does not have `--bare` option.

It does not match `grep -x #{vesion}`, because the `-x` option means "the whole line".


# Solution


Use `rbenv global` instaed of `rbenv version --bare`.



# Note


First, I tried using `rbenv version-name`, because it is suggested by the help.

```bash
$ rbenv version --help
Usage: rbenv version

Shows the currently selected Ruby version and how it was
selected. To obtain only the version string, use `rbenv
version-name'.
```

But I think `rbenv global` command is more appropriate. Because it is not affected by `.ruby-version`.
