### PR TITLE
Added make to RedHat platforms

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -21,6 +21,7 @@ when 'redhat', 'fedora', 'amazon'
   # redhat is including CentOS
   package 'bzip2'
   package 'gcc'
+  package 'make'
   package 'gdbm-devel'
   package 'libffi-devel'
   package 'libyaml-devel'


### PR DESCRIPTION
I got the following error with plain fedora31 instance on AWS.

```
[18.176.170.223]   INFO :       execute[rbenv install 2.5.7] executed will change from 'false' to 'true'
[18.176.170.223]  ERROR :         stderr | Downloading ruby-2.5.7.tar.bz2...
[18.176.170.223]  ERROR :         stderr | -> https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2
[18.176.170.223]  ERROR :         stderr | Installing ruby-2.5.7...
[18.176.170.223]  ERROR :         stderr |
[18.176.170.223]  ERROR :         stderr | BUILD FAILED (Fedora 31 using ruby-build 20200224)
[18.176.170.223]  ERROR :         stderr |
[18.176.170.223]  ERROR :         stderr | Inspect or clean up the working tree at /tmp/ruby-build.20200302052635.21585.NPkDCq
[18.176.170.223]  ERROR :         stderr | Results logged to /tmp/ruby-build.20200302052635.21585.log
[18.176.170.223]  ERROR :         stderr |
[18.176.170.223]  ERROR :         stderr | Last 10 log lines:
[18.176.170.223]  ERROR :         stderr | checking for _setjmp as a macro or function... yes
[18.176.170.223]  ERROR :         stderr | checking for sigsetjmp as a macro or function... no
[18.176.170.223]  ERROR :         stderr | checking for setjmp type... __builtin_setjmp
[18.176.170.223]  ERROR :         stderr | checking for prefix of external symbols... NONE
[18.176.170.223]  ERROR :         stderr | checking pthread.h usability... yes
[18.176.170.223]  ERROR :         stderr | checking pthread.h presence... yes
[18.176.170.223]  ERROR :         stderr | checking for pthread.h... yes
[18.176.170.223]  ERROR :         stderr | checking if make is GNU make... ./configure: line 27352: make: command not found
[18.176.170.223]  ERROR :         stderr | no
[18.176.170.223]  ERROR :         stderr | checking for safe null command for make... configure: error: no candidate for safe null command
[18.176.170.223]  ERROR :         Command `sudo -H -u chkbuild -- /bin/sh -c cd\ \~chkbuild\ \;\ \ \ export\ RBENV_ROOT\=/home/chkbuild/.rbenv'
[18.176.170.223]  ERROR :         '\ \ export\ PATH\=\"/home/chkbuild/.rbenv/bin:\$\{PATH\}\"'
[18.176.170.223]  ERROR :         '\ \ eval\ \"\$\(rbenv\ init\ --no-rehash\ -\)\"'
[18.176.170.223]  ERROR :         '\ \ rbenv\ install\ 2.5.7` failed. (exit status: 1)
[18.176.170.223]  ERROR :       execute[rbenv install 2.5.7] Failed.
```

